### PR TITLE
fix #9 - Settle down all the PIDs into one place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ VOLUME /openvpn
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["/usr/local/openvpn_as/scripts/openvpnas", "--nodaemon"]
+CMD ["/usr/local/openvpn_as/scripts/openvpnas", "--nodaemon", "--pidfile=/ovpn/tmp/openvpn.pid"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,8 +10,8 @@ if [ ! -c /dev/net/tun ]; then
 fi
 
 # clear old sock and pid files
-rm -rf /usr/local/openvpn_as/etc/sock/*
-rm -rf /usr/local/openvpn_as/etc/pid/*
+rm -rf /usr/local/openvpn_as/etc/sock/* /ovpn/sock/*
+rm -rf /usr/local/openvpn_as/etc/pid/* /ovpn/tmp/*.pid
 
 if [ ! -f /openvpn/etc/docker-init ]; then
     cp -a /usr/local/openvpn_as/etc /openvpn/


### PR DESCRIPTION
Before `twistd.pid` file was created in the root, which is not the best place to store pid files.
Moved to the location which is used in AS config. Added cleanup before start