### PR TITLE
Add `grep` to command for finding initial password

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ services:
 
 The admin interface is available at `https://DOCKER-HOST-IP:943/admin` (assuming bridge mode) with a default user 'openvpn' and the password can be found in the docker logs (on the first initial run):
 ```
-docker logs -f openvpn-as
+docker logs openvpn-as | grep "Auto-generated pass"
 ```
 
 To ensure your devices can connect to your VPN properly, go to Configuration -> Network Settings -> and change the "Hostname or IP Address" section to either your domain name or public ip address.


### PR DESCRIPTION
It took me a minute to find the password.

Results in a (relatively) neat:

<img width="656" alt="Screenshot 2025-05-31 at 10 04 31 AM" src="https://github.com/user-attachments/assets/84e3e8a2-9117-4452-872c-135eb5c7ebaf" />

I couldn't seem to get `tail` to work with it.